### PR TITLE
Fix the problem that the DB_Base module cannot be found when executin…

### DIFF
--- a/config/.env
+++ b/config/.env
@@ -8,5 +8,5 @@ DB_IDX_HOST = '127.0.0.1' #host
 DB_IDX_PORT = '5432' #port
 DB_NAME = 'unilit_idx' #name of the db
 
-TB_FILE = '../config/IDX_tables.yml' #table structure file.
-SP_FILE = '../config/Snapshots.yml'  #snapshot details file
+TB_FILE = 'config/IDX_tables.yml' #table structure file.
+SP_FILE = 'config/Snapshots.yml'  #snapshot details file

--- a/main/DB_init.py
+++ b/main/DB_init.py
@@ -1,12 +1,15 @@
 import os, sys
 from psycopg2 import sql, pool
 
-path_cst = os.path.abspath('../base/')+'/'
+current_file_path = os.path.abspath(__file__)
+current_directory = os.path.dirname(current_file_path)
+faster_directory =  os.path.abspath(os.path.join(current_directory, ".."))
+path_cst = f"{faster_directory}/base"
 sys.path.append(path_cst)
 from DB_Base import DB_Base
 
 from dotenv import load_dotenv
-dotenv_path = '../config/.env'
+dotenv_path = f'{faster_directory}/config/.env'
 load_dotenv(dotenv_path)
 
 def generate_a_db_manager():

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ To get a local copy up and running follow these simple example steps.
 
 9. run `main/Updater.py`
     ```sh
-    pip install psycopg2-binary tqdm python-dotenv
+    pip install psycopg2-binary tqdm python-dotenv pyyaml
     ```
 
     ```python


### PR DESCRIPTION
when I run ```python main/Updater.py``` in libltc20-indexer dir

```
(python_3.9) ➜  libltc20-indexer git:(main) ✗ python main/Updater.py
Traceback (most recent call last):
  File "/Users/yangmingming/Documents/git/libltc20-indexer/main/Updater.py", line 8, in <module>
    from Updater_wrapper import *
  File "/Users/yangmingming/Documents/git/libltc20-indexer/main/Updater_wrapper.py", line 11, in <module>
    from DB_init import *
  File "/Users/yangmingming/Documents/git/libltc20-indexer/main/DB_init.py", line 6, in <module>
    from DB_Base import DB_Base
ModuleNotFoundError: No module named 'DB_Base'
```

".." Indicates the upper-level directory of the current directory, and the upper-level directory of the directory where the current file is located should be used.
```
path_cst = os.path.abspath('../base/')+'/'
sys.path.append(path_cst)
```

So I modified it as follows
```
current_file_path = os.path.abspath(__file__)
current_directory = os.path.dirname(current_file_path)
path_cst = os.path.abspath('{current_directory}/../base/')+'/'
sys.path.append(path_cst)
```

So you can execute the command "python main/Updater.py`" in the project directory
